### PR TITLE
problems when going into profile page with another user account

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -8,13 +8,15 @@ import 'package:tiktok_tutorial/views/screens/profile_screen.dart';
 import 'package:tiktok_tutorial/views/screens/search_screen.dart';
 import 'package:tiktok_tutorial/views/screens/video_screen.dart';
 
-List pages = [
-  VideoScreen(),
-  SearchScreen(),
-  const AddVideoScreen(),
-  Text('Messages Screen'),
-  ProfileScreen(uid: authController.user.uid),
-];
+List navigatePages(String uid) {
+  return [
+    VideoScreen(),
+    SearchScreen(),
+    const AddVideoScreen(),
+    const Text('Messages Screen'), // this is to do .. I will add chat functionality..
+    ProfileScreen(uid: uid),
+  ];
+}
 
 // COLORS
 const backgroundColor = Colors.black;

--- a/lib/controllers/search_controller.dart
+++ b/lib/controllers/search_controller.dart
@@ -18,7 +18,10 @@ class SearchController extends GetxController {
       for (var elem in query.docs) {
         retVal.add(User.fromSnap(elem));
       }
-      return retVal;
+       List<User> outputList = retVal.where((item) => item.uid != authController.user.uid).toList();
+      return outputList;
+      // There was a bug where a search list returns the auth user when you type in the auth user name. 
+     
     }));
   }
 }

--- a/lib/views/screens/home_screen.dart
+++ b/lib/views/screens/home_screen.dart
@@ -49,7 +49,10 @@ class _HomeScreenState extends State<HomeScreen> {
           ),
         ],
       ),
-      body: pages[pageIdx],
+         body: navigatePages(authController.user.uid)[pageIdx],
+         // Original Code has a bug where if you sign out (a person A) and log in with another account (PersonB)
+         // and go to the profile page using bottomNavigationItem, the previous profile (Person A) appers not the other one
+         // I coulnd't figure out why it happens, so I inserted the user uid directly into function that returns the page list
     );
   }
 }


### PR DESCRIPTION
     Original Code has a bug where if you sign out (a person A) and log in with another account (PersonB) and go to the profile page using bottomNavigationItem, the previous profile (Person A) appears not the other one I couldn't figure out why it happens, so I inserted the user uid directly into function that returns the page list. I still don't know why the auth user uid doesn't get passed to profile page, but adding uid directly from the bottom navigation tap seems to fix the issue. I think since we set the Page List as constant, the auth user uid also became constant  rather than listening to the change of the auth state I hope it helps